### PR TITLE
Bringed back addEventHandler to be blocking, added new asynchronous event<> {} handler

### DIFF
--- a/src/main/kotlin/world/cepi/kstom/CoroutinesUtils.kt
+++ b/src/main/kotlin/world/cepi/kstom/CoroutinesUtils.kt
@@ -15,12 +15,3 @@ public val IOContext: ExecutorCoroutineDispatcher = Executors
 public val IOScope: CoroutineScope = CoroutineScope(IOContext)
 
 private const val eventBufferSize = 100
-
-/** Flow of all events */
-public val events: SharedFlow<Event> by lazy {
-    MutableSharedFlow<Event>(eventBufferSize).also { flow ->
-        MinecraftServer.getGlobalEventHandler().addEventCallback<Event> {
-            flow.emit(this)
-        }
-    }
-}

--- a/src/main/kotlin/world/cepi/kstom/CoroutinesUtils.kt
+++ b/src/main/kotlin/world/cepi/kstom/CoroutinesUtils.kt
@@ -13,5 +13,3 @@ public val IOContext: ExecutorCoroutineDispatcher = Executors
     .newFixedThreadPool(Runtime.getRuntime().availableProcessors())
     .asCoroutineDispatcher()
 public val IOScope: CoroutineScope = CoroutineScope(IOContext)
-
-private const val eventBufferSize = 100

--- a/src/main/kotlin/world/cepi/kstom/EventExtenders.kt
+++ b/src/main/kotlin/world/cepi/kstom/EventExtenders.kt
@@ -16,8 +16,8 @@ import kotlin.reflect.KClass
  */
 public inline fun <reified E : Event> EventHandler.addEventCallback(
     eventClass: KClass<E>,
-    crossinline eventCallback: suspend E.() -> Unit
-): Boolean = addEventCallback(eventClass.java) { IOScope.launch { it.eventCallback() } }
+    crossinline eventCallback: E.() -> Unit
+): Boolean = addEventCallback(eventClass.java) { it.eventCallback() }
 
 /**
  * Adds an event to an event handler using a Kotlin class, using Generics.
@@ -28,5 +28,18 @@ public inline fun <reified E : Event> EventHandler.addEventCallback(
  *
  */
 public inline fun <reified E: Event> EventHandler.addEventCallback(
+    crossinline eventCallback: E.() -> Unit
+): Boolean = addEventCallback(E::class.java) { it.eventCallback() }
+
+
+/**
+ * Adds an event to an asynchronous event handler using a Kotlin class, using Generics.
+ *
+ * @param eventCallback The lambda that runs when the event is triggered
+ *
+ * @return True if the element is unique, false if it isn't and it wasn't added
+ *
+ */
+public inline fun <reified E: Event> EventHandler.event(
     crossinline eventCallback: suspend E.() -> Unit
 ): Boolean = addEventCallback(E::class.java) { IOScope.launch { it.eventCallback() } }


### PR DESCRIPTION
Sometimes you need to block the event and do something with it. For example, canceling the event won't work if you launch a coroutine and cancel it there