### PR TITLE
Allow Kommands to have global conditions for all syntaxes

### DIFF
--- a/src/main/kotlin/world/cepi/kstom/command/kommand/KSyntax.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/KSyntax.kt
@@ -3,31 +3,31 @@ package world.cepi.kstom.command.kommand
 import net.minestom.server.command.builder.arguments.Argument
 
 class KSyntax(
-  vararg val arguments: Argument<*>,
-  override val conditions: MutableList<Kommand.ConditionContext.() -> Boolean> = mutableListOf(),
-  override val kommandReference: Kommand
+    vararg val arguments: Argument<*>,
+    override val conditions: MutableList<Kommand.ConditionContext.() -> Boolean> = mutableListOf(),
+    override val kommandReference: Kommand
 ) : Kondition<KSyntax>() {
-  override val t: KSyntax
-    get() = this
+    override val t: KSyntax
+        get() = this
 
-  operator fun invoke(executor: Kommand.SyntaxContext.() -> Unit) {
-    if (arguments.isEmpty()) {
-      kommandReference.command.setDefaultExecutor { sender, context ->
+    operator fun invoke(executor: Kommand.SyntaxContext.() -> Unit) {
+        if (arguments.isEmpty()) {
+            kommandReference.command.setDefaultExecutor { sender, context ->
 
-        if (!conditionPasses(Kommand.ConditionContext(sender, context.input))) return@setDefaultExecutor
+                if (!conditionPasses(Kommand.ConditionContext(sender, context.input))) return@setDefaultExecutor
 
-        executor(Kommand.SyntaxContext(sender, context))
-      }
+                executor(Kommand.SyntaxContext(sender, context))
+            }
 
-      return
+            return
+        }
+
+        kommandReference.command.addConditionalSyntax(
+            { sender, string -> conditionPasses(Kommand.ConditionContext(sender, string ?: "")) },
+            { sender, context -> executor(Kommand.SyntaxContext(sender, context)) },
+            *arguments
+        )
+
+        return
     }
-
-    kommandReference.command.addConditionalSyntax(
-      { sender, string -> conditionPasses(Kommand.ConditionContext(sender, string ?: "")) },
-      { sender, context -> executor(Kommand.SyntaxContext(sender, context)) },
-      *arguments
-    )
-
-    return
-  }
 }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
@@ -19,6 +19,10 @@ open class Kommand(val k: Kommand.() -> Unit, name: String, vararg aliases: Stri
 
     val command = Command(name, *aliases)
 
+    init {
+        k()
+    }
+
     data class SyntaxContext(val sender: CommandSender, val context: CommandContext) {
 
         val player by lazy { sender as Player }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
@@ -9,63 +9,63 @@ import org.jetbrains.annotations.Contract
 import world.cepi.kstom.Manager
 
 open class Kommand(val k: Kommand.() -> Unit, name: String, vararg aliases: String) : Kondition<Kommand>() {
-  override val conditions: MutableList<ConditionContext.() -> Boolean> = mutableListOf()
-  var playerCallbackFailMessage: (CommandSender) -> Unit = { }
-  var consoleCallbackFailMessage: (CommandSender) -> Unit = { }
+    override val conditions: MutableList<ConditionContext.() -> Boolean> = mutableListOf()
+    var playerCallbackFailMessage: (CommandSender) -> Unit = { }
+    var consoleCallbackFailMessage: (CommandSender) -> Unit = { }
 
-  override val t: Kommand
-    get() = this
-  override val kommandReference: Kommand by ::t
+    override val t: Kommand
+        get() = this
+    override val kommandReference: Kommand by ::t
 
-  val command = Command(name, *aliases)
+    val command = Command(name, *aliases)
 
-  data class SyntaxContext(val sender: CommandSender, val context: CommandContext) {
+    data class SyntaxContext(val sender: CommandSender, val context: CommandContext) {
 
-    val player by lazy { sender as Player }
+        val player by lazy { sender as Player }
 
-    operator fun <T> get(argument: Argument<T>): T = context[argument]
+        operator fun <T> get(argument: Argument<T>): T = context[argument]
 
-    operator fun <T> Argument<T>.not(): T = context[this]
-  }
+        operator fun <T> Argument<T>.not(): T = context[this]
+    }
 
-  data class ConditionContext(val sender: CommandSender, val input: String)
-  data class ArgumentCallbackContext(val sender: CommandSender, val exception: ArgumentSyntaxException)
+    data class ConditionContext(val sender: CommandSender, val input: String)
+    data class ArgumentCallbackContext(val sender: CommandSender, val exception: ArgumentSyntaxException)
 
-  @Contract(pure = true)
-  fun syntax(
-    vararg arguments: Argument<*> = arrayOf(),
-  ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this)
+    @Contract(pure = true)
+    fun syntax(
+        vararg arguments: Argument<*> = arrayOf(),
+    ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this)
 
-  @Contract(pure = true)
-  fun syntax(
-    vararg arguments: Argument<*> = arrayOf(),
-    executor: SyntaxContext.() -> Unit
-  ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this).invoke(executor)
+    @Contract(pure = true)
+    fun syntax(
+        vararg arguments: Argument<*> = arrayOf(),
+        executor: SyntaxContext.() -> Unit
+    ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this).invoke(executor)
 
-  inline fun argumentCallback(
-    arg: Argument<*>,
-    crossinline lambda: ArgumentCallbackContext.() -> Unit
-  ) {
-    command.setArgumentCallback({ source, value -> lambda(ArgumentCallbackContext(source, value)) }, arg)
-  }
+    inline fun argumentCallback(
+        arg: Argument<*>,
+        crossinline lambda: ArgumentCallbackContext.() -> Unit
+    ) {
+        command.setArgumentCallback({ source, value -> lambda(ArgumentCallbackContext(source, value)) }, arg)
+    }
 
-  inline fun <T> Argument<T>.failCallback(crossinline lambda: ArgumentCallbackContext.() -> Unit) {
-    setCallback { sender, exception -> lambda(ArgumentCallbackContext(sender, exception)) }
-  }
+    inline fun <T> Argument<T>.failCallback(crossinline lambda: ArgumentCallbackContext.() -> Unit) {
+        setCallback { sender, exception -> lambda(ArgumentCallbackContext(sender, exception)) }
+    }
 
-  inline fun default(crossinline block: SyntaxContext.() -> Unit) {
-    command.defaultExecutor = CommandExecutor { sender, args -> block(SyntaxContext(sender, args)) }
-  }
+    inline fun default(crossinline block: SyntaxContext.() -> Unit) {
+        command.defaultExecutor = CommandExecutor { sender, args -> block(SyntaxContext(sender, args)) }
+    }
 
-  fun addSubcommands(vararg subcommands: Command) {
-    subcommands.forEach { command.addSubcommand(it) }
-  }
+    fun addSubcommands(vararg subcommands: Command) {
+        subcommands.forEach { command.addSubcommand(it) }
+    }
 
-  fun addSubcommands(vararg subcommands: Kommand) {
-    subcommands.forEach { command.addSubcommand(it.command) }
-  }
+    fun addSubcommands(vararg subcommands: Kommand) {
+        subcommands.forEach { command.addSubcommand(it.command) }
+    }
 
-  fun register() {
-    Manager.command.register(command)
-  }
+    fun register() {
+        Manager.command.register(command)
+    }
 }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
@@ -1,73 +1,71 @@
 package world.cepi.kstom.command.kommand
 
 import net.minestom.server.command.CommandSender
-import net.minestom.server.command.builder.Command
-import net.minestom.server.command.builder.CommandContext
-import net.minestom.server.command.builder.CommandExecutor
-import net.minestom.server.command.builder.CommandSyntax
+import net.minestom.server.command.builder.*
 import net.minestom.server.command.builder.arguments.Argument
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException
 import net.minestom.server.entity.Player
 import org.jetbrains.annotations.Contract
 import world.cepi.kstom.Manager
 
-open class Kommand(val k : Kommand.() -> Unit, name: String, vararg aliases: String) {
+open class Kommand(val k: Kommand.() -> Unit, name: String, vararg aliases: String) : Kondition<Kommand>() {
+  override val conditions: MutableList<ConditionContext.() -> Boolean> = mutableListOf()
+  var playerCallbackFailMessage: (CommandSender) -> Unit = { }
+  var consoleCallbackFailMessage: (CommandSender) -> Unit = { }
 
-    var playerCallbackFailMessage: (CommandSender) -> Unit = { }
-    var consoleCallbackFailMessage: (CommandSender) -> Unit = { }
+  override val t: Kommand
+    get() = this
+  override val kommandReference: Kommand by ::t
 
-    val command = Command(name, *aliases)
+  val command = Command(name, *aliases)
 
-    data class SyntaxContext(val sender: CommandSender, val context: CommandContext) {
+  data class SyntaxContext(val sender: CommandSender, val context: CommandContext) {
 
-        val player by lazy { sender as Player }
+    val player by lazy { sender as Player }
 
-        operator fun <T> get(argument: Argument<T>): T = context[argument]
+    operator fun <T> get(argument: Argument<T>): T = context[argument]
 
-        operator fun <T> Argument<T>.not(): T = context[this]
-    }
+    operator fun <T> Argument<T>.not(): T = context[this]
+  }
 
-    data class ConditionContext(val sender: CommandSender, val input: String)
-    data class ArgumentCallbackContext(val sender: CommandSender, val exception: ArgumentSyntaxException)
+  data class ConditionContext(val sender: CommandSender, val input: String)
+  data class ArgumentCallbackContext(val sender: CommandSender, val exception: ArgumentSyntaxException)
 
-    @Contract(pure = true)
-    fun syntax(
-        vararg arguments: Argument<*> = arrayOf(),
-    ) = KSyntax(*arguments, kommandReference = this)
+  @Contract(pure = true)
+  fun syntax(
+    vararg arguments: Argument<*> = arrayOf(),
+  ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this)
 
-    @Contract(pure = true)
-    fun syntax(
-        vararg arguments: Argument<*> = arrayOf(),
-        executor: SyntaxContext.() -> Unit
-    ) = KSyntax(*arguments, kommandReference = this).invoke(executor)
+  @Contract(pure = true)
+  fun syntax(
+    vararg arguments: Argument<*> = arrayOf(),
+    executor: SyntaxContext.() -> Unit
+  ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this).invoke(executor)
 
-    inline fun argumentCallback(
-        arg: Argument<*>,
-        crossinline lambda: ArgumentCallbackContext.() -> Unit
-    ) {
-        command.setArgumentCallback({ source, value ->  lambda(ArgumentCallbackContext(source, value)) }, arg)
-    }
+  inline fun argumentCallback(
+    arg: Argument<*>,
+    crossinline lambda: ArgumentCallbackContext.() -> Unit
+  ) {
+    command.setArgumentCallback({ source, value -> lambda(ArgumentCallbackContext(source, value)) }, arg)
+  }
 
-    inline fun <T> Argument<T>.failCallback(crossinline lambda: ArgumentCallbackContext.() -> Unit) {
-        setCallback { sender, exception -> lambda(ArgumentCallbackContext(sender, exception)) }
-    }
+  inline fun <T> Argument<T>.failCallback(crossinline lambda: ArgumentCallbackContext.() -> Unit) {
+    setCallback { sender, exception -> lambda(ArgumentCallbackContext(sender, exception)) }
+  }
 
-    inline fun default(crossinline block: SyntaxContext.() -> Unit) {
-        command.defaultExecutor = CommandExecutor { sender, args ->  block(SyntaxContext(sender, args)) }
-    }
+  inline fun default(crossinline block: SyntaxContext.() -> Unit) {
+    command.defaultExecutor = CommandExecutor { sender, args -> block(SyntaxContext(sender, args)) }
+  }
 
-    fun addSubcommands(vararg subcommands: Command) {
-        subcommands.forEach { command.addSubcommand(it) }
-    }
+  fun addSubcommands(vararg subcommands: Command) {
+    subcommands.forEach { command.addSubcommand(it) }
+  }
 
-    fun addSubcommands(vararg subcommands: Kommand) {
-        subcommands.forEach { command.addSubcommand(it.command) }
-    }
+  fun addSubcommands(vararg subcommands: Kommand) {
+    subcommands.forEach { command.addSubcommand(it.command) }
+  }
 
-    fun register() {
-        Manager.command.register(command)
-    }
-
-
-
+  fun register() {
+    Manager.command.register(command)
+  }
 }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kondition.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kondition.kt
@@ -4,42 +4,42 @@ import net.minestom.server.command.ConsoleSender
 import net.minestom.server.entity.Player
 
 abstract class Kondition<T : Kondition<T>> {
-  abstract val conditions: MutableList<Kommand.ConditionContext.() -> Boolean>
-  abstract val t: T
-  abstract val kommandReference: Kommand
+    abstract val conditions: MutableList<Kommand.ConditionContext.() -> Boolean>
+    abstract val t: T
+    abstract val kommandReference: Kommand
 
-  fun conditionPasses(context: Kommand.ConditionContext) = conditions.all { it(context) }
+    fun conditionPasses(context: Kommand.ConditionContext) = conditions.all { it(context) }
 
-  fun condition(lambda: Kommand.ConditionContext.() -> Boolean): T {
-    conditions += lambda
-    return t
-  }
-
-  val onlyPlayers: T
-    get() = run {
-      conditions += condition@{
-        if (sender !is Player) {
-          kommandReference.playerCallbackFailMessage(sender)
-          return@condition false
-        }
-
-        return@condition true
-      }
-
-      return t
+    fun condition(lambda: Kommand.ConditionContext.() -> Boolean): T {
+        conditions += lambda
+        return t
     }
 
-  val onlyConsole: T
-    get() = run {
-      conditions += condition@{
-        if (sender !is ConsoleSender) {
-          kommandReference.consoleCallbackFailMessage(sender)
-          return@condition false
+    val onlyPlayers: T
+        get() = run {
+            conditions += condition@{
+                if (sender !is Player) {
+                    kommandReference.playerCallbackFailMessage(sender)
+                    return@condition false
+                }
+
+                return@condition true
+            }
+
+            return t
         }
 
-        return@condition true
-      }
+    val onlyConsole: T
+        get() = run {
+            conditions += condition@{
+                if (sender !is ConsoleSender) {
+                    kommandReference.consoleCallbackFailMessage(sender)
+                    return@condition false
+                }
 
-      return t
-    }
+                return@condition true
+            }
+
+            return t
+        }
 }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kondition.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kondition.kt
@@ -1,0 +1,45 @@
+package world.cepi.kstom.command.kommand
+
+import net.minestom.server.command.ConsoleSender
+import net.minestom.server.entity.Player
+
+abstract class Kondition<T : Kondition<T>> {
+  abstract val conditions: MutableList<Kommand.ConditionContext.() -> Boolean>
+  abstract val t: T
+  abstract val kommandReference: Kommand
+
+  fun conditionPasses(context: Kommand.ConditionContext) = conditions.all { it(context) }
+
+  fun condition(lambda: Kommand.ConditionContext.() -> Boolean): T {
+    conditions += lambda
+    return t
+  }
+
+  val onlyPlayers: T
+    get() = run {
+      conditions += condition@{
+        if (sender !is Player) {
+          kommandReference.playerCallbackFailMessage(sender)
+          return@condition false
+        }
+
+        return@condition true
+      }
+
+      return t
+    }
+
+  val onlyConsole: T
+    get() = run {
+      conditions += condition@{
+        if (sender !is ConsoleSender) {
+          kommandReference.consoleCallbackFailMessage(sender)
+          return@condition false
+        }
+
+        return@condition true
+      }
+
+      return t
+    }
+}


### PR DESCRIPTION
# Description
This pull request creates the possibility to have command wide conditions. So all syntaxes use these conditions. This is useful for permission reasons or other conditions that apply to all the commands.

## Old: 
```kotlin
object New : Kommand({
    val add by literal
    val remove by literal
    val set by literal

    val amount by ArgumentType::Integer.delegate { min(0) }

    syntax().onlyPlayers {
        sender.sendMessage("Usage: add|remove|set <amount>")
    }

    syntax(add, amount).onlyPlayers {
        player.level += !amount
    }

    syntax(remove, amount).onlyPlayers {
        player.level = (player.level - !amount).coerceAtLeast(0)
    }

    syntax(set, amount).onlyPlayers {
        player.level = !amount
    }


}, "hey")
```
## Becomes:
```kotlin
object New : Kommand({
    val add by literal
    val remove by literal
    val set by literal

    val amount by ArgumentType::Integer.delegate { min(0) }

    onlyPlayers

    syntax {
        sender.sendMessage("Usage: add|remove|set <amount>")
    }

    syntax(add, amount) {
        player.level += !amount
    }

    syntax(remove, amount) {
        player.level = (player.level - !amount).coerceAtLeast(0)
    }

    syntax(set, amount) {
        player.level = !amount
    }


}, "hey")
```