### PR TITLE
Small API updates

### DIFF
--- a/src/main/kotlin/world/cepi/kstom/adventure/AdventureMinestomUtils.kt
+++ b/src/main/kotlin/world/cepi/kstom/adventure/AdventureMinestomUtils.kt
@@ -4,7 +4,12 @@ import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 
-public fun String.asMini(): Component = MiniMessage.get().parse(this)
-public fun Audience.sendMiniMessage(miniMessage: String): Unit = this.sendMessage(miniMessage.asMini())
+public fun String.asMini(placeholders: Map<String, String> = mapOf()): Component = MiniMessage.get().parse(this)
+
+public fun Audience.sendMiniMessage(miniMessage: String, placeholders: Map<String, String> = mapOf()): Unit =
+    this.sendMessage(miniMessage.asMini(placeholders))
+
+fun Component.plainText(): String = PlainTextComponentSerializer.plainText().serialize(this)
 fun Component.legacyAmpersand(): String = LegacyComponentSerializer.legacyAmpersand().serialize(this)

--- a/src/main/kotlin/world/cepi/kstom/adventure/AdventureMinestomUtils.kt
+++ b/src/main/kotlin/world/cepi/kstom/adventure/AdventureMinestomUtils.kt
@@ -6,7 +6,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 
-public fun String.asMini(placeholders: Map<String, String> = mapOf()): Component = MiniMessage.get().parse(this)
+public fun String.asMini(placeholders: Map<String, String> = mapOf()): Component = MiniMessage.get().parse(this, placeholders)
 
 public fun Audience.sendMiniMessage(miniMessage: String, placeholders: Map<String, String> = mapOf()): Unit =
     this.sendMessage(miniMessage.asMini(placeholders))

--- a/src/main/kotlin/world/cepi/kstom/serializer/BlockSerializer.kt
+++ b/src/main/kotlin/world/cepi/kstom/serializer/BlockSerializer.kt
@@ -1,37 +1,45 @@
 package world.cepi.kstom.serializer
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
 import net.minestom.server.instance.block.Block
 import net.minestom.server.utils.NamespaceID
 import org.jglrxavpok.hephaistos.nbt.NBT
 import org.jglrxavpok.hephaistos.nbt.NBTCompound
 
-@Serializable
-internal data class BlockSurrogate(
-    @Serializable(with = NamespaceIDSerializer::class)
-    val namespaceId: NamespaceID,
-    @Serializable(with = NBTSerializer::class)
-    val blockNbt: NBT
-)
-
+@Serializer(forClass = Block::class)
+@OptIn(ExperimentalSerializationApi::class)
 object BlockSerializer : KSerializer<Block> {
-    override val descriptor: SerialDescriptor = BlockSurrogate.serializer().descriptor
-
-    override fun deserialize(decoder: Decoder): Block {
-        val blockSurrogate = decoder.decodeSerializableValue(BlockSurrogate.serializer())
-
-        val nbtCompound = blockSurrogate.blockNbt as? NBTCompound
-        val block = Block.fromNamespaceId(blockSurrogate.namespaceId)
-
-        return block?.let { block.withNbt(nbtCompound) } ?: Block.AIR
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Block") {
+        element("namespace", NamespaceIDSerializer.descriptor)
+        element<NBT>("nbt")
     }
 
     override fun serialize(encoder: Encoder, value: Block) {
-        val blockSurrogate = BlockSurrogate(value.namespace(), value.nbt() ?: NBTCompound())
-        encoder.encodeSerializableValue(BlockSurrogate.serializer(), blockSurrogate)
+        encoder.encodeStructure(descriptor) {
+            encodeSerializableElement(descriptor, 0, NamespaceIDSerializer, value.namespace())
+            encodeSerializableElement(descriptor, 1, NBTSerializer, value.nbt() ?: NBTCompound() as NBT)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Block = decoder.decodeStructure(descriptor) {
+        var namespaceID: NamespaceID? = null
+        var nbt: NBTCompound? = null
+
+        while (true) {
+            when (val index = decodeElementIndex(descriptor)) {
+                0 -> namespaceID = decodeSerializableElement(descriptor, 0, NamespaceIDSerializer)
+                1 -> nbt = decodeSerializableElement(descriptor, 1, NBTSerializer) as? NBTCompound ?: NBTCompound()
+                CompositeDecoder.DECODE_DONE -> break
+                else -> error("Unexpected index: $index")
+            }
+        }
+
+        namespaceID?.let { Block.fromNamespaceId(it)?.withNbt(nbt) } ?: Block.AIR
     }
 }

--- a/src/main/kotlin/world/cepi/kstom/serializer/BlockSerializer.kt
+++ b/src/main/kotlin/world/cepi/kstom/serializer/BlockSerializer.kt
@@ -1,10 +1,37 @@
 package world.cepi.kstom.serializer
 
-import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import net.minestom.server.instance.block.Block
+import net.minestom.server.utils.NamespaceID
+import org.jglrxavpok.hephaistos.nbt.NBT
+import org.jglrxavpok.hephaistos.nbt.NBTCompound
 
-@OptIn(ExperimentalSerializationApi::class)
-object BlockSerializer : AbstractProtocolObjectSerializer<Block>(Block::class) {
-    override fun deserialize(decoder: Decoder): Block = Block.fromNamespaceId(decoder.decodeString())!!
+@Serializable
+internal data class BlockSurrogate(
+    @Serializable(with = NamespaceIDSerializer::class)
+    val namespaceId: NamespaceID,
+    @Serializable(with = NBTSerializer::class)
+    val blockNbt: NBT
+)
+
+object BlockSerializer : KSerializer<Block> {
+    override val descriptor: SerialDescriptor = BlockSurrogate.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): Block {
+        val blockSurrogate = decoder.decodeSerializableValue(BlockSurrogate.serializer())
+
+        val nbtCompound = blockSurrogate.blockNbt as? NBTCompound
+        val block = Block.fromNamespaceId(blockSurrogate.namespaceId)
+
+        return block?.let { block.withNbt(nbtCompound) } ?: Block.AIR
+    }
+
+    override fun serialize(encoder: Encoder, value: Block) {
+        val blockSurrogate = BlockSurrogate(value.namespace(), value.nbt() ?: NBTCompound())
+        encoder.encodeSerializableValue(BlockSurrogate.serializer(), blockSurrogate)
+    }
 }

--- a/src/main/kotlin/world/cepi/kstom/serializer/MinestomSerializableModule.kt
+++ b/src/main/kotlin/world/cepi/kstom/serializer/MinestomSerializableModule.kt
@@ -9,6 +9,7 @@ import net.minestom.server.entity.EntityType
 import kotlin.reflect.KClass
 
 val MinestomSerializableModule = SerializersModule {
+    contextual(BlockSerializer)
     contextual(ItemStackSerializer)
     contextual(PotionSerializer)
     contextual(NBTSerializer)

--- a/src/main/kotlin/world/cepi/kstom/util/InventoryUtils.kt
+++ b/src/main/kotlin/world/cepi/kstom/util/InventoryUtils.kt
@@ -2,6 +2,8 @@ package world.cepi.kstom.util
 
 import net.minestom.server.inventory.Inventory
 import net.minestom.server.item.ItemStack
+import kotlin.math.max
+import kotlin.math.min
 
 fun Inventory.clone(): Inventory {
     val clonedInventory = Inventory(this.inventoryType, this.title)
@@ -19,17 +21,43 @@ fun Inventory.setItemStacks(itemStacksToAdd: Map<Int, ItemStack>) {
 fun Inventory.setItemStacks(vararg itemStacksToAdd: Pair<Int, ItemStack>) = setItemStacks(itemStacksToAdd.toMap())
 
 /**
+ * Allows you to map specific ItemStack's to a character. Useful for creating configurable inventories.
+ */
+fun Inventory.mapItemStacks(shape: List<String>, mappings: Map<Char, ItemStack>) {
+    for (y in 0 until min(this.size / 9, shape.size)) {
+        val row = shape[y]
+        val characters = row.toCharArray()
+
+        for (x in 0 until min(9, characters.size)) {
+            val currentCharacter = characters[x]
+            this.setItemStack(x, y, mappings[currentCharacter] ?: ItemStack.AIR)
+        }
+    }
+}
+
+/**
  * Allows use of x and y for inventories. Won't work properly for inventories other than hopper or rowed chests
  */
 fun Inventory.getSlotNumber(x: Int, y: Int): Int {
     val slotNumber = y * 9 + x
 
-    if (x > 8 || x < 0 || slotNumber > this.size || slotNumber < this.size) throw IndexOutOfBoundsException()
+    if (x > 8 || x < 0 || slotNumber > this.size || slotNumber < 0) throw IndexOutOfBoundsException()
 
     return slotNumber
 }
 
 operator fun Inventory.get(slot: Int) = this.getItemStack(slot)
+
+operator fun Inventory.get(range: IntRange): List<ItemStack> {
+    val itemStacks = mutableListOf<ItemStack>()
+
+    for (slot in max(0, range.first)..min(this.size, range.last)) {
+        itemStacks.add(this[slot])
+    }
+
+    return itemStacks
+}
+
 operator fun Inventory.set(slot: Int, itemStack: ItemStack) = this.setItemStack(slot, itemStack)
 
 /**

--- a/src/test/kotlin/world/cepi/kstom/inventory/MappedInventoryTests.kt
+++ b/src/test/kotlin/world/cepi/kstom/inventory/MappedInventoryTests.kt
@@ -1,0 +1,40 @@
+package world.cepi.kstom.inventory
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.kyori.adventure.text.Component
+import net.minestom.server.inventory.Inventory
+import net.minestom.server.inventory.InventoryType
+import net.minestom.server.item.ItemStack
+import net.minestom.server.item.Material
+import world.cepi.kstom.util.get
+import world.cepi.kstom.util.mapItemStacks
+
+class MappedInventoryTests: StringSpec ({
+    "Mapped inventory should have correct items" {
+        val shape = listOf(
+            "#########",
+            "000000000",
+            "111",
+            "22222222222",
+            "3"
+        )
+
+        val map = mapOf(
+            '#' to ItemStack.of(Material.FEATHER),
+            '0' to ItemStack.of(Material.LEATHER),
+            '1' to ItemStack.of(Material.ARROW),
+            '2' to ItemStack.of(Material.RED_CONCRETE),
+            '3' to ItemStack.of(Material.DIAMOND)
+        )
+
+        val inventory = Inventory(InventoryType.CHEST_4_ROW, Component.empty())
+        inventory.mapItemStacks(shape, map)
+
+        inventory[0..8].all { it.material == Material.FEATHER } shouldBe true
+        inventory[9..17].all { it.material == Material.LEATHER } shouldBe true
+        inventory[18..20].all { it.material == Material.ARROW } shouldBe true
+        inventory[21..26].all { it.material == Material.AIR } shouldBe true
+        inventory[27..35].all { it.material == Material.RED_CONCRETE } shouldBe true
+    }
+})

--- a/src/test/kotlin/world/cepi/kstom/serialization/BlockSerializerTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/serialization/BlockSerializerTest.kt
@@ -1,0 +1,31 @@
+package world.cepi.kstom.serialization
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.minestom.server.instance.block.Block
+import org.jglrxavpok.hephaistos.nbt.NBTCompound
+import world.cepi.kstom.serializer.BlockSerializer
+import world.cepi.kstom.serializer.MinestomJSON
+
+class BlockSerializerTest: StringSpec ({
+    "block without nbt data should have empty compound" {
+        val block = Block.CHEST
+
+        val encodeToString = MinestomJSON.encodeToString(BlockSerializer, block)
+        val decodeFromString = MinestomJSON.decodeFromString(BlockSerializer, encodeToString)
+
+        decodeFromString shouldBe block.withNbt(NBTCompound())
+    }
+
+    "block with nbt data should serialize correct" {
+        val nbtCompound = NBTCompound()
+        nbtCompound.setString("data", "my awesome data!")
+
+        val block = Block.CHEST.withNbt(nbtCompound)
+
+        val encodeToString = MinestomJSON.encodeToString(BlockSerializer, block)
+        val decodeFromString = MinestomJSON.decodeFromString(BlockSerializer, encodeToString)
+
+        decodeFromString shouldBe block
+    }
+})


### PR DESCRIPTION
Add nbt serialization to BlockSerializer. If a block contains no nbt data, an empty compound will be used.
Add minimessage placeholder support (defaults to empty map) and a plain text serialization extension. 