### PR TITLE
Allow for a specific ItemMetaBuilder to be passed into the item DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
 
     // Add MiniMessage
-    implementation("net.kyori:adventure-text-minimessage:4.1.0-SNAPSHOT")
+    implementation("net.kyori:adventure-text-minimessage:4.2.0-SNAPSHOT")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/src/main/kotlin/world/cepi/kstom/item/KItem.kt
+++ b/src/main/kotlin/world/cepi/kstom/item/KItem.kt
@@ -3,12 +3,25 @@ package world.cepi.kstom.item
 import net.minestom.server.item.*
 
 /**
+ * DSL for Items with special meta.
+ *
+ * @param T The type of the item meta builder
+ *
+ * @param material The material of the item
+ * @param amount The amount of item to have
+ * @param init The DSL lambda
+ */
+fun <T : ItemMetaBuilder> item(material: Material = Material.PAPER, amount: Int = 1, init: T.() -> Unit = {}): ItemStack {
+    return ItemStack.of(material, amount).withMeta { metaBuilder: T -> init(metaBuilder); metaBuilder }
+}
+
+/**
  * DSL for Items.
  *
  * @param material The material of the item
  * @param amount The amount of item to have
  * @param init The DSL lambda
  */
-fun item(material: Material = Material.PAPER, amount: Int = 1, init: ItemMetaBuilder.() -> Unit = {}): ItemStack {
-    return ItemStack.of(material, amount).withMeta { metaBuilder: ItemMetaBuilder -> init(metaBuilder); metaBuilder }
-}
+@JvmName("itemDefault") // Doesn't matter because this library won't be used from Java
+fun item(material: Material = Material.PAPER, amount: Int = 1, init: ItemMetaBuilder.() -> Unit = {}): ItemStack =
+    item<ItemMetaBuilder>(material, amount, init)

--- a/src/main/kotlin/world/cepi/kstom/item/KMeta.kt
+++ b/src/main/kotlin/world/cepi/kstom/item/KMeta.kt
@@ -3,10 +3,17 @@ package world.cepi.kstom.item
 import net.minestom.server.item.*
 
 /**
- * DSL for Meta.
+ * DSL for Meta of specific type.
  */
-fun ItemStackBuilder.withMeta(init: ItemMetaBuilder.() -> Unit) =
-    this.meta { it: ItemMetaBuilder ->
+fun <T : ItemMetaBuilder> ItemStackBuilder.withMeta(init: T.() -> Unit) =
+    this.meta { it: T ->
         it.init()
         return@meta it
     }
+
+/**
+ * DSL for Meta.
+ */
+@JvmName("withMetaDefault") // Doesn't matter because this library won't be used from Java
+fun ItemStackBuilder.withMeta(init: ItemMetaBuilder.() -> Unit) =
+    this.withMeta<ItemMetaBuilder>(init)

--- a/src/test/kotlin/world/cepi/kstom/item/ItemTests.kt
+++ b/src/test/kotlin/world/cepi/kstom/item/ItemTests.kt
@@ -4,16 +4,22 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import net.kyori.adventure.text.Component
+import net.minestom.server.item.Material
+import net.minestom.server.item.metadata.WrittenBookMeta
 import world.cepi.kstom.nbt.classes.CollectionClass
 import world.cepi.kstom.nbt.classes.ComplexClass
 import world.cepi.kstom.nbt.classes.InterestingClass
 
 class ItemTests : StringSpec({
-    val item = item(amount = 5) {
+    val item = item<WrittenBookMeta.Builder>(material = Material.WRITTEN_BOOK, amount = 5) {
         lore = listOf(Component.text("Hello!"))
         displayName = Component.text("Hey!")
         damage = 5
         unbreakable = true
+
+        title("My first book")
+        author("Notch")
+        pages(Component.text("This is the first page"))
 
         this["complexData"] = ComplexClass(5, 4, 2, true, InterestingClass("hey", 'h'))
         this["complexListData"] = CollectionClass(5, 9, 3, listOf(4, 3))
@@ -36,5 +42,9 @@ class ItemTests : StringSpec({
 
     "data should return null if not found" {
         item.meta.get<ComplexClass>("weirdData").shouldBeNull()
+    }
+    
+    "book meta author should be Notch" {
+        (item.meta as WrittenBookMeta).author.shouldBe("Notch")
     }
 })


### PR DESCRIPTION
Optionally allow for the following syntax while using the item DSL

```kt
val item = item<WrittenBookMeta.Builder>(material = Material.WRITTEN_BOOK, amount = 5) {
        title("My first book")
        author("Notch")
        pages(Component.text("This is the first page"))
}
```

The old syntax without the generic is still valid, and will just default to `ItemMetaBuilder`