### PR TITLE
Add TagDelegate to create extension properties backed by tags

### DIFF
--- a/src/main/kotlin/world/cepi/kstom/tag/TagDelegate.kt
+++ b/src/main/kotlin/world/cepi/kstom/tag/TagDelegate.kt
@@ -1,0 +1,16 @@
+package world.cepi.kstom.tag
+
+import net.minestom.server.tag.Tag
+import net.minestom.server.tag.TagReadable
+import net.minestom.server.tag.TagWritable
+import kotlin.reflect.KProperty
+
+class TagDelegate<T>(private val tag: Tag<T>) {
+    operator fun getValue(thisRef: TagReadable?, property: KProperty<*>): T? {
+        return thisRef?.getTag(tag)
+    }
+
+    operator fun setValue(thisRef: TagWritable?, property: KProperty<*>, value: T) {
+        thisRef?.setTag(tag, value)
+    }
+}

--- a/src/test/kotlin/world/cepi/kstom/tag/TagDelegateTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/tag/TagDelegateTest.kt
@@ -1,0 +1,35 @@
+package world.cepi.kstom.tag
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import net.minestom.server.entity.Entity
+import net.minestom.server.entity.EntityType
+import net.minestom.server.item.ItemStack
+import net.minestom.server.item.Material
+import net.minestom.server.tag.Tag
+import world.cepi.kstom.item.item
+
+val ItemStack.canCutTrees by TagDelegate(Tag.Boolean("canCutTreeTag"))
+var Entity.friendlyName by TagDelegate(Tag.String("friendlyName"))
+
+class TagDelegateTest : StringSpec({
+
+    "getting tag from TagReadable should work" {
+        val itemStack = item(Material.WOODEN_AXE) {
+            setTag(Tag.Boolean("canCutTreeTag"), true)
+        }
+
+        itemStack.canCutTrees shouldBe true
+    }
+
+    "setting tag on TagWritable with delegate should work" {
+        val entity = Entity(EntityType.ZOMBIFIED_PIGLIN)
+
+        entity.getTag(Tag.String("friendlyName")) shouldBe null
+
+        entity.friendlyName = "Zombie Piglin"
+
+        entity.getTag(Tag.String("friendlyName")) shouldBe "Zombie Piglin"
+    }
+
+})


### PR DESCRIPTION
Add a nice TagDelegate that allows you to easily create extension properties that are backed by tags. This makes it easier to access tags. I saw ryleu doing this manually and thought it was cool, then realized I could make it into a delegate. 

Usage is as follows:
```kt
val ItemStack.canCutTrees by TagDelegate(Tag.Boolean("canCutTreeTag"))
var Instance.name by TagDelegate(Tag.String("name"))
```