### PR TITLE
feat(coroutine): Add dispatchers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     // Use the kotlin test library
     testImplementation("io.kotest:kotest-assertions-core:5.4.0")
     testImplementation("io.kotest:kotest-runner-junit5:5.4.0")
+    testImplementation("io.mockk:mockk:1.12.4")
 
     // Add support for kotlinx courotines
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
@@ -1,6 +1,7 @@
 package world.cepi.kstom.command.kommand
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.minestom.server.command.CommandSender
 import net.minestom.server.command.builder.*
@@ -9,7 +10,7 @@ import net.minestom.server.command.builder.exception.ArgumentSyntaxException
 import net.minestom.server.entity.Player
 import org.jetbrains.annotations.Contract
 import world.cepi.kstom.Manager
-import world.cepi.kstom.dispatcher.asyncDispatcher
+import world.cepi.kstom.dispatcher.MinestomAsync
 import kotlin.coroutines.CoroutineContext
 
 open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases: String) : Kondition<Kommand>() {
@@ -54,7 +55,7 @@ open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases:
 
     @Contract(pure = true)
     fun syntaxSuspending(
-        context: CoroutineContext = asyncDispatcher,
+        context: CoroutineContext = Dispatchers.MinestomAsync,
         vararg arguments: Argument<*> = arrayOf(),
         executor: suspend SyntaxContext.() -> Unit
     ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this).invoke {
@@ -76,7 +77,7 @@ open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases:
         command.defaultExecutor = CommandExecutor { sender, args -> block(SyntaxContext(sender, args)) }
     }
 
-    inline fun defaultSuspending(context: CoroutineContext = asyncDispatcher, crossinline block: suspend SyntaxContext.() -> Unit) {
+    inline fun defaultSuspending(context: CoroutineContext = Dispatchers.MinestomAsync, crossinline block: suspend SyntaxContext.() -> Unit) {
         command.defaultExecutor = CommandExecutor { sender, args ->
             CoroutineScope(context).launch { block(SyntaxContext(sender, args)) }
         }

--- a/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
+++ b/src/main/kotlin/world/cepi/kstom/command/kommand/Kommand.kt
@@ -1,7 +1,6 @@
 package world.cepi.kstom.command.kommand
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.minestom.server.command.CommandSender
 import net.minestom.server.command.builder.*
@@ -10,6 +9,7 @@ import net.minestom.server.command.builder.exception.ArgumentSyntaxException
 import net.minestom.server.entity.Player
 import org.jetbrains.annotations.Contract
 import world.cepi.kstom.Manager
+import world.cepi.kstom.dispatcher.asyncDispatcher
 import kotlin.coroutines.CoroutineContext
 
 open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases: String) : Kondition<Kommand>() {
@@ -54,7 +54,7 @@ open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases:
 
     @Contract(pure = true)
     fun syntaxSuspending(
-        context: CoroutineContext = Dispatchers.IO,
+        context: CoroutineContext = asyncDispatcher,
         vararg arguments: Argument<*> = arrayOf(),
         executor: suspend SyntaxContext.() -> Unit
     ) = KSyntax(*arguments, conditions = conditions.toMutableList(), kommandReference = this).invoke {
@@ -76,7 +76,7 @@ open class Kommand(val k: Kommand.() -> Unit = {}, name: String, vararg aliases:
         command.defaultExecutor = CommandExecutor { sender, args -> block(SyntaxContext(sender, args)) }
     }
 
-    inline fun defaultSuspending(context: CoroutineContext = Dispatchers.IO, crossinline block: suspend SyntaxContext.() -> Unit) {
+    inline fun defaultSuspending(context: CoroutineContext = asyncDispatcher, crossinline block: suspend SyntaxContext.() -> Unit) {
         command.defaultExecutor = CommandExecutor { sender, args ->
             CoroutineScope(context).launch { block(SyntaxContext(sender, args)) }
         }

--- a/src/main/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcher.kt
+++ b/src/main/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcher.kt
@@ -1,0 +1,29 @@
+package world.cepi.kstom.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import net.minestom.server.MinecraftServer
+import net.minestom.server.ServerProcess
+import net.minestom.server.timer.ExecutionType
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * @see [AsyncCoroutineDispatcher]
+ */
+val asyncDispatcher: CoroutineDispatcher get() = AsyncCoroutineDispatcher(MinecraftServer.process())
+
+/**
+ * Dispatcher to execute task in a [async][ExecutionType.ASYNC] context of the server.
+ * @property serverProcess Server's process
+ */
+internal class AsyncCoroutineDispatcher(
+    private val serverProcess: ServerProcess
+): CoroutineDispatcher() {
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        if (!serverProcess.isAlive) {
+            return
+        }
+
+        serverProcess.scheduler().scheduleNextProcess(block, ExecutionType.ASYNC)
+    }
+}

--- a/src/main/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcher.kt
+++ b/src/main/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcher.kt
@@ -1,6 +1,7 @@
 package world.cepi.kstom.dispatcher
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import net.minestom.server.MinecraftServer
 import net.minestom.server.ServerProcess
 import net.minestom.server.timer.ExecutionType
@@ -9,7 +10,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * @see [AsyncCoroutineDispatcher]
  */
-val asyncDispatcher: CoroutineDispatcher get() = AsyncCoroutineDispatcher(MinecraftServer.process())
+val Dispatchers.MinestomAsync: CoroutineDispatcher get() = AsyncCoroutineDispatcher(MinecraftServer.process())
 
 /**
  * Dispatcher to execute task in a [async][ExecutionType.ASYNC] context of the server.

--- a/src/main/kotlin/world/cepi/kstom/dispatcher/SyncDispatcher.kt
+++ b/src/main/kotlin/world/cepi/kstom/dispatcher/SyncDispatcher.kt
@@ -1,0 +1,29 @@
+package world.cepi.kstom.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import net.minestom.server.MinecraftServer
+import net.minestom.server.ServerProcess
+import net.minestom.server.timer.ExecutionType
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * @see [SyncCoroutineDispatcher]
+ */
+val syncDispatcher: CoroutineDispatcher get() = SyncCoroutineDispatcher(MinecraftServer.process())
+
+/**
+ * Dispatcher to execute task in a [sync][ExecutionType.SYNC] context of the server.
+ * @property serverProcess Server's process
+ */
+internal class SyncCoroutineDispatcher(
+    private val serverProcess: ServerProcess
+): CoroutineDispatcher() {
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        if (!serverProcess.isAlive) {
+            return
+        }
+
+        serverProcess.scheduler().scheduleNextProcess(block, ExecutionType.SYNC)
+    }
+}

--- a/src/main/kotlin/world/cepi/kstom/dispatcher/SyncDispatcher.kt
+++ b/src/main/kotlin/world/cepi/kstom/dispatcher/SyncDispatcher.kt
@@ -1,6 +1,7 @@
 package world.cepi.kstom.dispatcher
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import net.minestom.server.MinecraftServer
 import net.minestom.server.ServerProcess
 import net.minestom.server.timer.ExecutionType
@@ -9,7 +10,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * @see [SyncCoroutineDispatcher]
  */
-val syncDispatcher: CoroutineDispatcher get() = SyncCoroutineDispatcher(MinecraftServer.process())
+val Dispatchers.MinestomSync: CoroutineDispatcher get() = SyncCoroutineDispatcher(MinecraftServer.process())
 
 /**
  * Dispatcher to execute task in a [sync][ExecutionType.SYNC] context of the server.

--- a/src/main/kotlin/world/cepi/kstom/event/EventDSL.kt
+++ b/src/main/kotlin/world/cepi/kstom/event/EventDSL.kt
@@ -1,11 +1,11 @@
 package world.cepi.kstom.event
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.minestom.server.event.Event
 import net.minestom.server.event.EventListener
 import net.minestom.server.event.EventNode
+import world.cepi.kstom.dispatcher.asyncDispatcher
 import kotlin.coroutines.CoroutineContext
 
 class KEventListener<T : Event>(val eventListener: EventListener.Builder<T>) {
@@ -20,7 +20,7 @@ class KEventListener<T : Event>(val eventListener: EventListener.Builder<T>) {
 
     fun handler(lambda: T.() -> Unit) = eventListener.handler(lambda)
 
-    fun suspendingHandler(context: CoroutineContext = Dispatchers.IO, lambda: suspend T.() -> Unit) = eventListener.handler {
+    fun suspendingHandler(context: CoroutineContext = asyncDispatcher, lambda: suspend T.() -> Unit) = eventListener.handler {
         CoroutineScope(context).launch {
             lambda(it)
         }

--- a/src/main/kotlin/world/cepi/kstom/event/EventDSL.kt
+++ b/src/main/kotlin/world/cepi/kstom/event/EventDSL.kt
@@ -1,11 +1,12 @@
 package world.cepi.kstom.event
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.minestom.server.event.Event
 import net.minestom.server.event.EventListener
 import net.minestom.server.event.EventNode
-import world.cepi.kstom.dispatcher.asyncDispatcher
+import world.cepi.kstom.dispatcher.MinestomAsync
 import kotlin.coroutines.CoroutineContext
 
 class KEventListener<T : Event>(val eventListener: EventListener.Builder<T>) {
@@ -20,7 +21,7 @@ class KEventListener<T : Event>(val eventListener: EventListener.Builder<T>) {
 
     fun handler(lambda: T.() -> Unit) = eventListener.handler(lambda)
 
-    fun suspendingHandler(context: CoroutineContext = asyncDispatcher, lambda: suspend T.() -> Unit) = eventListener.handler {
+    fun suspendingHandler(context: CoroutineContext = Dispatchers.MinestomAsync, lambda: suspend T.() -> Unit) = eventListener.handler {
         CoroutineScope(context).launch {
             lambda(it)
         }

--- a/src/test/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcherTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcherTest.kt
@@ -1,0 +1,46 @@
+package world.cepi.kstom.dispatcher
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.minestom.server.ServerProcess
+import net.minestom.server.timer.ExecutionType
+import net.minestom.server.timer.SchedulerManager
+import net.minestom.server.timer.Task
+
+class AsyncDispatcherTest : StringSpec({
+
+    "Should not perform if process is not alive" {
+        val process = mockk<ServerProcess>()
+        every { process.isAlive } returns false
+        val schedulerManager = mockk<SchedulerManager>()
+        every { process.scheduler() } returns schedulerManager
+        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk<Task>()
+
+        val dispatcher = AsyncCoroutineDispatcher(process)
+
+        val runnable = mockk<Runnable>()
+        dispatcher.dispatch(mockk(), runnable)
+
+        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.ASYNC) }
+        verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
+    }
+
+    "Should perform task in sync context" {
+        val process = mockk<ServerProcess>()
+        every { process.isAlive } returns true
+        val schedulerManager = mockk<SchedulerManager>()
+        every { process.scheduler() } returns schedulerManager
+        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk()
+
+        val dispatcher = SyncCoroutineDispatcher(process)
+
+        val runnable = mockk<Runnable>()
+        dispatcher.dispatch(mockk(), runnable)
+
+        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.ASYNC) }
+        verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
+    }
+
+})

--- a/src/test/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcherTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/dispatcher/AsyncDispatcherTest.kt
@@ -16,14 +16,11 @@ class AsyncDispatcherTest : StringSpec({
         every { process.isAlive } returns false
         val schedulerManager = mockk<SchedulerManager>()
         every { process.scheduler() } returns schedulerManager
-        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk<Task>()
 
         val dispatcher = AsyncCoroutineDispatcher(process)
+        dispatcher.dispatch(mockk()) {}
 
-        val runnable = mockk<Runnable>()
-        dispatcher.dispatch(mockk(), runnable)
-
-        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.ASYNC) }
+        verify(exactly = 0) { schedulerManager.scheduleNextProcess(any(), any()) }
         verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
     }
 

--- a/src/test/kotlin/world/cepi/kstom/dispatcher/SyncDispatcherTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/dispatcher/SyncDispatcherTest.kt
@@ -1,0 +1,45 @@
+package world.cepi.kstom.dispatcher
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.minestom.server.ServerProcess
+import net.minestom.server.timer.ExecutionType
+import net.minestom.server.timer.SchedulerManager
+
+class SyncDispatcherTest : StringSpec({
+
+    "Should not perform if process is not alive" {
+        val process = mockk<ServerProcess>()
+        every { process.isAlive } returns false
+        val schedulerManager = mockk<SchedulerManager>()
+        every { process.scheduler() } returns schedulerManager
+        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk()
+
+        val dispatcher = SyncCoroutineDispatcher(process)
+
+        val runnable = mockk<Runnable>()
+        dispatcher.dispatch(mockk(), runnable)
+
+        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.SYNC) }
+        verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
+    }
+
+    "Should perform task in sync context" {
+        val process = mockk<ServerProcess>()
+        every { process.isAlive } returns true
+        val schedulerManager = mockk<SchedulerManager>()
+        every { process.scheduler() } returns schedulerManager
+        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk()
+
+        val dispatcher = SyncCoroutineDispatcher(process)
+
+        val runnable = mockk<Runnable>()
+        dispatcher.dispatch(mockk(), runnable)
+
+        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.SYNC) }
+        verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
+    }
+
+})

--- a/src/test/kotlin/world/cepi/kstom/dispatcher/SyncDispatcherTest.kt
+++ b/src/test/kotlin/world/cepi/kstom/dispatcher/SyncDispatcherTest.kt
@@ -15,14 +15,11 @@ class SyncDispatcherTest : StringSpec({
         every { process.isAlive } returns false
         val schedulerManager = mockk<SchedulerManager>()
         every { process.scheduler() } returns schedulerManager
-        every { schedulerManager.scheduleNextProcess(mockk(), mockk()) } returns mockk()
 
         val dispatcher = SyncCoroutineDispatcher(process)
+        dispatcher.dispatch(mockk()) {}
 
-        val runnable = mockk<Runnable>()
-        dispatcher.dispatch(mockk(), runnable)
-
-        verify(exactly = 1) { schedulerManager.scheduleNextProcess(runnable, ExecutionType.SYNC) }
+        verify(exactly = 1) { schedulerManager.scheduleNextProcess(any(), any()) }
         verify(exactly = 0) { schedulerManager.scheduleNextTick(any()) }
     }
 


### PR DESCRIPTION
Linked to #156

# Issue

The implementation is a few limited. In all case, we will dispatch the coroutine (see the [documentation of CoroutineDispatcher](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-dispatcher/#-381715142%2FFunctions%2F1975948010)).

To avoid that, we need to know if we are in Sync or Async context. So I created an [issue](https://github.com/Minestom/Minestom/issues/1284) in Minestom repository.
If the functionality is implemented, we will be able to choose if the coroutine need a dispatch or not according to the context and the type of dispatcher

# To do

- [x] Create coroutine dispatchers using Minestom system
- [ ] Tests 